### PR TITLE
add filter_by_rating and filter_by_category

### DIFF
--- a/src-tauri/src/commands/item.rs
+++ b/src-tauri/src/commands/item.rs
@@ -29,6 +29,23 @@ pub fn delete_item(state: State<AppState>, id: usize) -> CommandResult<()> {
 
 #[command]
 #[allow(clippy::needless_pass_by_value)]
+pub fn filter_by_rating(state: State<AppState>, range: Vec<usize>) -> CommandResult<Vec<Item>> {
+    let conn = state.db.conn.lock().unwrap();
+    db::filter_by_rating(&conn, range)
+}
+
+#[command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn filter_by_category(
+    state: State<AppState>,
+    categories: Vec<String>,
+) -> CommandResult<Vec<Item>> {
+    let conn = state.db.conn.lock().unwrap();
+    db::filter_by_category(&conn, categories)
+}
+
+#[command]
+#[allow(clippy::needless_pass_by_value)]
 pub fn get_items(state: State<AppState>) -> CommandResult<Vec<Item>> {
     let conn = state.db.conn.lock().unwrap();
     db::get_items(&conn)

--- a/src-tauri/src/filters.rs
+++ b/src-tauri/src/filters.rs
@@ -1,15 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+use crate::{errors::CommandResult, schema::Item};
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Filter {
     category: Option<Vec<String>>,
     rating: Option<Vec<String>>,
-}
-
-fn repeat_vars(count: usize) -> String {
-    assert_ne!(count, 0);
-    let mut s = "?,".repeat(count);
-    // Remove trailing comma
-    s.pop();
-    s
 }


### PR DESCRIPTION
both fully unit tested and set up with front-end exported invoke functions.

filter_by_rating expects an array/vec of numbers : `[3,4] OR [2] OR [1,2,3,4]`

filter_by_category expects an array/vec of category names : `["Food"] OR ["Drink"]`, "Exercise"]

